### PR TITLE
Fixed this.$months undefined

### DIFF
--- a/week-picker.js
+++ b/week-picker.js
@@ -90,11 +90,12 @@
 
             this.$months.empty();
             this.renderView();
+            var me = this;
 
             $('.week', this.$months).click($.proxy(function (e) {
                 this.update($(e.target).parent().attr("date"));
             }, this)).hover(function (e) {
-                    $('.highlighted', this.$months).removeClass('highlighted');
+                    $('.highlighted', me.$months).removeClass('highlighted');
                     $(this).addClass('highlighted');
                 });
 


### PR DESCRIPTION
the 'this' in this.$months refers to the hovered object, not to the instance of weekpicker. The result is that undefined is passed, and ANY .highlighted element on the page has the class removed - not just within weekpicker.